### PR TITLE
Fixes for minor SwiftLint issues

### DIFF
--- a/AudioPlayerManager/.swiftlint.yml
+++ b/AudioPlayerManager/.swiftlint.yml
@@ -39,10 +39,14 @@ line_length:
 type_body_length:
   - 400 #warning
   - 500 #error
-  
+
 opt_in_rules:
   - missing_docs
   - force_unwrapping
+
+identifier_name:
+  excluded:
+    - Log(_:file:function:line:)
 
 custom_rules:
   comments_space:

--- a/AudioPlayerManager/.swiftlint.yml
+++ b/AudioPlayerManager/.swiftlint.yml
@@ -47,7 +47,7 @@ opt_in_rules:
 custom_rules:
   comments_space:
     name: "Space After Comment"
-    regex: "(^ *//\w+)"
+    regex: '(^ *//\w+)'
     message: "There should be a space after //"
     severity: error
   comments_capitalized_ignore_possible_code:
@@ -57,27 +57,27 @@ custom_rules:
     severity: error
   empty_first_line:
     name: "Empty First Line"
-    regex: "(^[ a-zA-Z ]*(?:protocol|extension|class|struct) (?!(?:var|let))[ a-zA-Z:]*\{\n *\S+)"
+    regex: '(^[ a-zA-Z ]*(?:protocol|extension|class|struct) (?!(?:var|let))[ a-zA-Z:]*\{\n *\S+)'
     message: "There should be an empty line after a declaration"
     severity: error
   empty_line_after_guard:
     name: "Empty Line After Guard"
-    regex: "(^ *guard[ a-zA-Z0-9=?.\(\),><!]*\{[ a-zA-Z0-9=?.\(\),><!]*\}\n *(?!(?:return|guard))\S+)"
+    regex: '(^ *guard[ a-zA-Z0-9=?.\(\),><!]*\{[ a-zA-Z0-9=?.\(\),><!]*\}\n *(?!(?:return|guard))\S+)'
     message: "There should be an empty line after a guard"
     severity: error
   empty_line_after_super:
     name: "Empty Line After Super"
-    regex: "(^ *super\.[ a-zA-Z0-9=?.\(\)\{\}:,><!]*\n *(?!(?:\}|return))\S+)"
+    regex: '(^ *super\.[ a-zA-Z0-9=?.\(\)\{\}:,><!]*\n *(?!(?:\}|return))\S+)'
     message: "There should be an empty line after super"
     severity: error
   multiple_empty_lines:
     name: "Multiple Empty Lines"
-    regex: "((?:\s*\n){3,})"
+    regex: '((?:\s*\n){3,})'
     message: "There are too many line breaks"
     severity: error
   unnecessary_type:
     name: "Unnecessary Type"
-    regex: "[ a-zA-Z0-9]*(?:let|var) [ a-zA-Z0-9]*: ([a-zA-Z0-9]*)[\? ]*= \1"
+    regex: '[ a-zA-Z0-9]*(?:let|var) [ a-zA-Z0-9]*: ([a-zA-Z0-9]*)[\? ]*= \1'
     message: "Type Definition Not Needed"
     severity: error
 


### PR DESCRIPTION
When using the latest SwiftLint (`0.18.1`) the build would throw `error: scanner: while parsing a quoted scalar`. Few of the regex strings were escaping the enclosing double quotes so I switched to single quotes. Also, the `Log` method would also prevent the build from succeeding and just I added an exclude case for this.