### PR TITLE
Development

### DIFF
--- a/AudioPlayerManager/Core/Public/Player/AudioPlayerManager+URL.swift
+++ b/AudioPlayerManager/Core/Public/Player/AudioPlayerManager+URL.swift
@@ -5,6 +5,7 @@
 //  Created by Hans Seiffert on 02.08.16.
 //  Copyright © 2016 Hans Seiffert. All rights reserved.
 //
+
 import MediaPlayer
 
 extension AudioPlayerManager {

--- a/AudioPlayerManager/Core/Public/Player/AudioPlayerManager.swift
+++ b/AudioPlayerManager/Core/Public/Player/AudioPlayerManager.swift
@@ -151,13 +151,7 @@ open class AudioPlayerManager: NSObject {
 	open func replace(with audioTracks: [AudioTrack], at startIndex: Int) {
 		Log("replace(audioTracks: \(audioTracks.count) tracks, startIndex: \(startIndex))")
 		self.stop()
-		var reducedTracks = [] as [AudioTrack]
-		for index in 0..<audioTracks.count {
-			let audioTrack = audioTracks[index]
-			reducedTracks.append(audioTrack)
-		}
-
-		self.queue.replace(reducedTracks, at: startIndex)
+		self.queue.replace(audioTracks, at: startIndex)
 		self.queueGeneration += 1
 	}
 
@@ -225,11 +219,11 @@ open class AudioPlayerManager: NSObject {
 	// MARK: - Rewind
 
 	open func canRewind() -> Bool {
-		guard let _currentTrack = self.currentTrack else {
+		guard let currentTrack = self.currentTrack else {
 			return false
 		}
 
-		if ((_currentTrack.currentTimeInSeconds() > Float(1)) || self.canRewindInQueue()) {
+		if ((currentTrack.currentTimeInSeconds() > Float(1)) || self.canRewindInQueue()) {
 			return true
 		}
 

--- a/AudioPlayerManager/Core/Public/Player/AudioPlayerManager.swift
+++ b/AudioPlayerManager/Core/Public/Player/AudioPlayerManager.swift
@@ -43,7 +43,7 @@ open class AudioPlayerManager: NSObject {
 	open var bufferStrategy						= BufferStrategy.minimizeStalling {
 		didSet {
 			if #available(iOS 10.0, *) {
-				self.player?.automaticallyWaitsToMinimizeStalling = self.bufferStrategy == .minimizeStalling
+				self.player.automaticallyWaitsToMinimizeStalling = self.bufferStrategy == .minimizeStalling
 			}
 		}
 	}
@@ -53,7 +53,7 @@ open class AudioPlayerManager: NSObject {
 	open var preferredForwardBufferDuration		= TimeInterval(0) {
 		didSet {
 			if #available(iOS 10.0, *) {
-				self.player?.currentItem?.preferredForwardBufferDuration = self.preferredForwardBufferDuration
+				self.player.currentItem?.preferredForwardBufferDuration = self.preferredForwardBufferDuration
 			}
 		}
 	}
@@ -98,6 +98,7 @@ open class AudioPlayerManager: NSObject {
 	open func setup() {
 		self.setupRemoteControlEvents()
 		self.setupAudioSession()
+		self.setupPlayer()
 	}
 
 	// MARK: - Control playback
@@ -117,17 +118,15 @@ open class AudioPlayerManager: NSObject {
 	}
 
 	open func play(updateNowPlayingInfo: Bool = false) {
-		if let _player = self.player {
-			_player.play()
-			if (updateNowPlayingInfo == true || self.didStopPlayback == true) {
-				self.updateNowPlayingInfoIfNeeded()
-			}
-			self.didStopPlayback = false
-			self.startPlaybackTimeChangeTimer()
-			self.callPlayStateChangeCallbacks()
-			if let _currentTrack = self.currentTrack {
-				NotificationCenter.default.post(name: Notification.Name(rawValue: self.playerStateChangedNotificationKey(track: _currentTrack)), object: nil)
-			}
+		self.player.play()
+		if (updateNowPlayingInfo == true || self.didStopPlayback == true) {
+			self.updateNowPlayingInfoIfNeeded()
+		}
+		self.didStopPlayback = false
+		self.startPlaybackTimeChangeTimer()
+		self.callPlayStateChangeCallbacks()
+		if let _currentTrack = self.currentTrack {
+			NotificationCenter.default.post(name: Notification.Name(rawValue: self.playerStateChangedNotificationKey(track: _currentTrack)), object: nil)
 		}
 	}
 
@@ -185,14 +184,12 @@ open class AudioPlayerManager: NSObject {
 	// MARK: - Pause
 
 	open func pause() {
-		if let _player = self.player {
-			_player.pause()
-			self.stopPlaybackTimeChangeTimer = true
-			self.callPlaybackTimeChangeCallbacks()
-			self.callPlayStateChangeCallbacks()
-			if let _currentTrack = self.currentTrack {
-				NotificationCenter.default.post(name: Notification.Name(rawValue: self.playerStateChangedNotificationKey(track: _currentTrack)), object: nil)
-			}
+		self.player.pause()
+		self.stopPlaybackTimeChangeTimer = true
+		self.callPlaybackTimeChangeCallbacks()
+		self.callPlayStateChangeCallbacks()
+		if let _currentTrack = self.currentTrack {
+			NotificationCenter.default.post(name: Notification.Name(rawValue: self.playerStateChangedNotificationKey(track: _currentTrack)), object: nil)
 		}
 	}
 
@@ -202,7 +199,7 @@ open class AudioPlayerManager: NSObject {
 			if (clearQueue == true) {
 				self.clearQueue()
 			} else {
-				self.player?.seek(to: CMTimeMake(0, 1))
+				self.player.seek(to: CMTimeMake(0, 1))
 				self.pause()
 			}
 			self.callPlayStateChangeCallbacks()
@@ -252,7 +249,7 @@ open class AudioPlayerManager: NSObject {
 			}
 		} else {
 			// Move to the beginning of the track if we aren't in the beginning.
-			self.player?.seek(to: CMTimeMake(0, 1))
+			self.player.seek(to: CMTimeMake(0, 1))
 			// Update the now playing info to show the new playback time
 			self.updateNowPlayingInfoIfNeeded()
 			// Call the callbacks to inform about the new time
@@ -261,7 +258,7 @@ open class AudioPlayerManager: NSObject {
 	}
 
 	open func seek(toTime time: CMTime) {
-		self.player?.seek(to: time)
+		self.player.seek(to: time)
 	}
 
 	open func seek(toProgress progress: Float) {
@@ -312,11 +309,7 @@ open class AudioPlayerManager: NSObject {
 	// MARK: - Helper
 
 	open func isPlaying() -> Bool {
-		guard let _player = self.player else {
-			return false
-		}
-
-		return _player.rate > 0
+		return (self.player.rate > 0)
 	}
 
 	// MARK: - INTERNAL -
@@ -349,7 +342,7 @@ open class AudioPlayerManager: NSObject {
 
 	fileprivate let audioPlayerManagerStateChangedPrefix	= "AudioPlayerManager.\(UUID().uuidString).playerStateChanged"
 
-	fileprivate var player									: AVPlayer?
+	fileprivate var player									= AVPlayer()
 
 	fileprivate var queue									= AudioTracksQueue()
 
@@ -371,16 +364,17 @@ open class AudioPlayerManager: NSObject {
 		let _ = try? AVAudioSession.sharedInstance().setActive(true)
 	}
 
-	fileprivate func initPlayer() {
+	fileprivate func setupPlayer() {
 		if #available(iOS 10.0, *) {
-			self.player?.automaticallyWaitsToMinimizeStalling = self.bufferStrategy == .minimizeStalling
+			self.player.automaticallyWaitsToMinimizeStalling = self.bufferStrategy == .minimizeStalling
 		}
 
-		if (self.player?.responds(to: #selector(setter: AVAudioMixing.volume)) == true) {
-			self.player?.volume = 1.0
+		if (self.player.responds(to: #selector(setter: AVAudioMixing.volume)) == true) {
+			self.player.volume = 1.0
 		}
-		self.player?.allowsExternalPlayback = true
-		self.player?.usesExternalPlaybackWhileExternalScreenIsActive = true
+
+		self.player.allowsExternalPlayback = true
+		self.player.usesExternalPlaybackWhileExternalScreenIsActive = true
 	}
 
 	fileprivate func setupRemoteControlEvents() {
@@ -400,15 +394,13 @@ open class AudioPlayerManager: NSObject {
 		}
 
 		if let _currentTrack = self.queue.currentTrack {
-			self.player = AVPlayer()
-			self.initPlayer()
 			_currentTrack.loadResource()
 			if let _playerItem = _currentTrack.avPlayerItem() {
 				if #available(iOS 10.0, *) {
 					_playerItem.preferredForwardBufferDuration = self.preferredForwardBufferDuration
 				}
 				_currentTrack.prepareForPlaying(_playerItem)
-				self.player?.replaceCurrentItem(with: _playerItem)
+				self.player.replaceCurrentItem(with: _playerItem)
 				self.play(updateNowPlayingInfo: true)
 			}
 		}
@@ -433,7 +425,7 @@ open class AudioPlayerManager: NSObject {
 	private func clearQueue() {
 		self.queue.replace(nil, at: 0)
 		self.queueGeneration += 1
-		self.player?.replaceCurrentItem(with: nil)
+		self.player.replaceCurrentItem(with: nil)
 	}
 
 	// MARK: - Plaback time change callback
@@ -450,6 +442,7 @@ open class AudioPlayerManager: NSObject {
 				}
 			}
 		}
+
 		if (self.stopPlaybackTimeChangeTimer == true) {
 			self.playbackPositionChangeTimer?.invalidate()
 		}

--- a/AudioPlayerManager/Core/Public/Track/AVAsset+Metadata.swift
+++ b/AudioPlayerManager/Core/Public/Track/AVAsset+Metadata.swift
@@ -37,7 +37,9 @@ public extension AVAsset {
 	open func loadDuration(completion: @escaping ((NSNumber?) -> Void)) {
 		self.loadAttributeAsynchronously(.duration) {
 			guard let durationInSeconds = self.loadedAttributeValue(for: .duration) as CMTime? else {
-				completion(nil)
+				DispatchQueue.main.async {
+					completion(nil)
+				}
 				return
 			}
 
@@ -45,14 +47,18 @@ public extension AVAsset {
 			let timeInSeconds = CMTimeGetSeconds(durationInSeconds)
 			// Check ig the time isn't NaN. This can happen eg. for podcasts
 			let duration = ((timeInSeconds.isNaN == false) ? NSNumber(value: Float(timeInSeconds)) : nil)
-			completion(duration)
+			DispatchQueue.main.async {
+				completion(duration)
+			}
 		}
 	}
 
 	open func loadMetadata(completion: @escaping (([AVMetadataItem]) -> Void)) {
 		self.loadAttributeAsynchronously(.metadata) {
 			let metadataItems = self.loadedAttributeValue(for: .metadata) as [AVMetadataItem]?
-			completion(metadataItems ?? [])
+			DispatchQueue.main.async {
+				completion(metadataItems ?? [])
+			}
 		}
 	}
 }

--- a/AudioPlayerManager/Core/Public/Track/AVAsset+Metadata.swift
+++ b/AudioPlayerManager/Core/Public/Track/AVAsset+Metadata.swift
@@ -6,7 +6,6 @@
 //
 
 import AVFoundation
-import MediaPlayer
 
 public enum DynamicAttribute {
 

--- a/AudioPlayerManager/Core/Public/Track/AVAsset+Metadata.swift
+++ b/AudioPlayerManager/Core/Public/Track/AVAsset+Metadata.swift
@@ -1,0 +1,58 @@
+//
+//  AVAsset+Metadata.swift
+//  AudioPlayerManager
+//
+//  Created by Kevin Delord on 31.05.18.
+//
+
+import AVFoundation
+import MediaPlayer
+
+public extension AVAsset {
+
+	private enum DynamicAttribute: String {
+
+		case duration = "duration"
+		case metadata = "commonMetadata"
+	}
+
+	private func loadAttributeAsynchronously(_ attribute: DynamicAttribute, completion: (() -> Void)?) {
+		self.loadValuesAsynchronously(forKeys: [attribute.rawValue], completionHandler: completion)
+	}
+
+	private func loadedAttributeValue<T>(for attribute: DynamicAttribute) -> T? {
+		var error : NSError? = nil
+		let status = self.statusOfValue(forKey: attribute.rawValue, error: &error)
+		if let error = error {
+			Log("Error loading asset value for key '\(attribute.rawValue)': \(error)")
+		}
+
+		guard (status == .loaded) else {
+			return nil
+		}
+
+		return self.value(forKey: attribute.rawValue) as? T
+	}
+
+	open func loadDuration(completion: @escaping ((NSNumber?) -> Void)) {
+		self.loadAttributeAsynchronously(.duration) {
+			guard let durationInSeconds = self.loadedAttributeValue(for: .duration) as CMTime? else {
+				completion(nil)
+				return
+			}
+
+			// Read duration from asset
+			let timeInSeconds = CMTimeGetSeconds(durationInSeconds)
+			// Check ig the time isn't NaN. This can happen eg. for podcasts
+			let duration = ((timeInSeconds.isNaN == false) ? NSNumber(value: Float(timeInSeconds)) : nil)
+			completion(duration)
+		}
+	}
+
+	open func loadMetadata(completion: @escaping (([AVMetadataItem]) -> Void)) {
+		self.loadAttributeAsynchronously(.metadata) {
+			let metadataItems = self.loadedAttributeValue(for: .metadata) as [AVMetadataItem]?
+			completion(metadataItems ?? [])
+		}
+	}
+}

--- a/AudioPlayerManager/Core/Public/Track/AudioTrack.swift
+++ b/AudioPlayerManager/Core/Public/Track/AudioTrack.swift
@@ -120,7 +120,7 @@ open class AudioTrack : NSObject {
 
 	open func updateNowPlayingInfoPlaybackTime() {
 		let currentTime = self.currentTimeInSeconds()
-		// Check ig the time isn't NaN.
+		// Check if the time isn't NaN.
 		let currentTimeAsNumber : NSNumber? = ((currentTime.isNaN == false) ? NSNumber(value: Float(currentTime)) : nil)
 		self.nowPlayingInfo?[MPNowPlayingInfoPropertyElapsedPlaybackTime] = currentTimeAsNumber
 	}

--- a/AudioPlayerManager/Core/Public/Track/AudioTrack.swift
+++ b/AudioPlayerManager/Core/Public/Track/AudioTrack.swift
@@ -113,12 +113,9 @@ open class AudioTrack : NSObject {
 	// MARK: - Now playing info
 
 	open func updateNowPlayingInfoPlaybackDuration() {
-		if let _playerItem = self.playerItem {
-			let timeInSeconds = CMTimeGetSeconds(_playerItem.asset.duration)
-			// Check ig the time isn't NaN. This can happen eg. for podcasts
-			let duration = ((timeInSeconds.isNaN == false) ? NSNumber(value: Float(timeInSeconds)) : nil)
-			self.nowPlayingInfo?[MPMediaItemPropertyPlaybackDuration] = duration
-		}
+		self.playerItem?.asset.loadDuration(completion: { [weak self] (duration: NSNumber?) in
+			self?.nowPlayingInfo?[MPMediaItemPropertyPlaybackDuration] = duration
+		})
 	}
 
 	open func updateNowPlayingInfoPlaybackTime() {
@@ -155,3 +152,4 @@ open class AudioTrack : NSObject {
 		return dateComponentsFormatter.string(from: timeInterval) ?? AudioTrack.Formats.durationStringForNilObject
 	}
 }
+

--- a/AudioPlayerManager/Core/Public/Track/AudioURLTrack+Metadata.swift
+++ b/AudioPlayerManager/Core/Public/Track/AudioURLTrack+Metadata.swift
@@ -14,7 +14,7 @@ extension AudioURLTrack {
 
 	internal func extractMetadata() {
 		Log("Extracting meta data of player item with url: \(self.url)")
-		self.playerItem?.asset.loadMetadata() { [weak self] (items: [AVMetadataItem]) in
+		self.playerItem?.asset.load(.commonMetadata, completion: { [weak self] (items: [AVMetadataItem]) in
 			let parsedMetadata = self?.parseMetadataItems(items)
 			self?.nowPlayingInfo?.merge((parsedMetadata ?? [:]), uniquingKeysWith: { (_, new) -> NSObject in
 				return new
@@ -22,7 +22,7 @@ extension AudioURLTrack {
 
 			// Inform the player about the updated meta data
 			AudioPlayerManager.shared.didUpdateMetadata()
-		}
+		})
 	}
 
 	/// Extract necessary info from loaded metadata items.

--- a/AudioPlayerManager/Core/Public/Track/AudioURLTrack+Metadata.swift
+++ b/AudioPlayerManager/Core/Public/Track/AudioURLTrack+Metadata.swift
@@ -1,0 +1,66 @@
+//
+//  AudioURLTrack+Metadata.swift
+//  AudioPlayerManager
+//
+//  Created by Kevin Delord on 31.05.18.
+//
+
+import AVFoundation
+import MediaPlayer
+
+// MARK: - Metadata
+
+extension AudioURLTrack {
+
+	internal func extractMetadata() {
+		Log("Extracting meta data of player item with url: \(self.url)")
+		self.playerItem?.asset.loadMetadata() { [weak self] (items: [AVMetadataItem]) in
+			let parsedMetadata = self?.parseMetadataItems(items)
+			self?.nowPlayingInfo?.merge((parsedMetadata ?? [:]), uniquingKeysWith: { (_, new) -> NSObject in
+				return new
+			})
+
+			// Inform the player about the updated meta data
+			AudioPlayerManager.shared.didUpdateMetadata()
+		}
+	}
+
+	/// Extract necessary info from loaded metadata items.
+	/// By default only the Title, AlbumName, Artist and Artwork values will be kept.
+	/// Override to add any other metadata.
+	///
+	/// - Parameter items: Array of fully loaded metadata items.
+	/// - Returns: Dictionary for metadata key values.
+	open func parseMetadataItems(_ items: [AVMetadataItem]) -> [String: NSObject] {
+		var info = [String: NSObject]()
+		for metadataItem in items {
+			if let key = metadataItem.commonKey {
+				switch key {
+				case AVMetadataCommonKeyTitle		: info[MPMediaItemPropertyTitle] = metadataItem.stringValue as NSObject?
+				case AVMetadataCommonKeyAlbumName	: info[MPMediaItemPropertyAlbumTitle] = metadataItem.stringValue as NSObject?
+				case AVMetadataCommonKeyArtist		: info[MPMediaItemPropertyArtist] = metadataItem.stringValue as NSObject?
+				case AVMetadataCommonKeyArtwork		: info[MPMediaItemPropertyArtwork] = self.mediaItemArtwork(from: metadataItem.dataValue)
+				default								: continue
+				}
+			}
+		}
+
+		return info
+	}
+
+	fileprivate func mediaItemArtwork(from data: Data?) -> MPMediaItemArtwork? {
+		guard
+			let data = data,
+			let image = UIImage(data: data) else {
+				return nil
+		}
+
+		if #available(iOS 10.0, *) {
+			return MPMediaItemArtwork(boundsSize: image.size, requestHandler: { (size: CGSize) -> UIImage in
+				return image
+			})
+		} else {
+			return MPMediaItemArtwork(image: image)
+		}
+	}
+}

--- a/AudioPlayerManager/Core/Public/Track/AudioURLTrack.swift
+++ b/AudioPlayerManager/Core/Public/Track/AudioURLTrack.swift
@@ -7,14 +7,13 @@
 //
 
 import Foundation
-import AVFoundation
 import MediaPlayer
 
-open class AudioURLTrack: AudioTrack {
+open class AudioURLTrack	: AudioTrack {
 
 	// MARK: - Properties
 
-	open var url		: URL?
+	open var url			: URL?
 
 	// MARK: - Initialization
 
@@ -87,6 +86,7 @@ open class AudioURLTrack: AudioTrack {
 		if let _urlAbsoluteString = self.url?.absoluteString {
 			return _urlAbsoluteString
 		}
+
 		return super.identifier()
 	}
 
@@ -101,57 +101,24 @@ open class AudioURLTrack: AudioTrack {
 	open class func firstPlayableItem(_ urls: [URL?], at startIndex: Int) -> (track: AudioURLTrack, index: Int)? {
 		// Iterate through all URLs and check whether it's not nil
 		for index in startIndex..<urls.count {
-			if let _track = AudioURLTrack(url: urls[index]) {
+			if let track = AudioURLTrack(url: urls[index]) {
 				// Create the track from the first playable URL and return it.
-				return (track: _track, index: index)
+				return (track: track, index: index)
 			}
 		}
+
 		// There is no playable URL -> reuturn nil then
 		return nil
-	}
-
-	// MARK: - PRIVATE -
-
-	fileprivate struct Keys {
-		static let timedMetadata		= "timedMetadata"
-	}
-
-	fileprivate func extractMetadata() {
-		Log("Extracting meta data of player item with url: \(url)")
-		for metadataItem in (self.playerItem?.asset.commonMetadata ?? []) {
-			if let _key = metadataItem.commonKey {
-				switch _key {
-				case AVMetadataCommonKeyTitle		: self.nowPlayingInfo?[MPMediaItemPropertyTitle] = metadataItem.stringValue as NSObject?
-				case AVMetadataCommonKeyAlbumName	: self.nowPlayingInfo?[MPMediaItemPropertyAlbumTitle] = metadataItem.stringValue as NSObject?
-				case AVMetadataCommonKeyArtist		: self.nowPlayingInfo?[MPMediaItemPropertyArtist] = metadataItem.stringValue as NSObject?
-				case AVMetadataCommonKeyArtwork		:
-					if
-						let _data = metadataItem.dataValue,
-						let _image = UIImage(data: _data) {
-							self.nowPlayingInfo?[MPMediaItemPropertyArtwork] = self.mediaItemArtwork(from: _image)
-					}
-				default								: continue
-				}
-			}
-		}
-		// Inform the player about the updated meta data
-		AudioPlayerManager.shared.didUpdateMetadata()
-	}
-
-	fileprivate func mediaItemArtwork(from image: UIImage) -> MPMediaItemArtwork {
-		if #available(iOS 10.0, *) {
-			return MPMediaItemArtwork(boundsSize: image.size, requestHandler: { (size: CGSize) -> UIImage in
-				return image
-			})
-		} else {
-			return MPMediaItemArtwork(image: image)
-		}
 	}
 }
 
 // MARK: - KVO
 
 extension AudioURLTrack {
+
+	fileprivate struct Keys {
+		static let timedMetadata = "timedMetadata"
+	}
 
 	override open func observeValue(forKeyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
 		if (forKeyPath == Keys.timedMetadata) {

--- a/AudioPlayerManager/Core/Public/Track/AudioURLTrack.swift
+++ b/AudioPlayerManager/Core/Public/Track/AudioURLTrack.swift
@@ -77,6 +77,7 @@ open class AudioURLTrack	: AudioTrack {
 	open override func initNowPlayingInfo() {
 		super.initNowPlayingInfo()
 
+		// Import `MediaPlayer` framework for the property title key.
 		self.nowPlayingInfo?[MPMediaItemPropertyTitle] = self.url?.lastPathComponent as NSObject?
 	}
 


### PR DESCRIPTION
# Description

- Made the `AVPlayer` a class attribute of the `AudioPlayerManager` and execute the setup.
- The instance of `AVPlayer` is not an optional anymore.
- Remove a bit of unnecessary code (`reducedTracks `).
- Load the asset attributes `duration` and `commonMetadata` before usage.
- Add open `parseMetadataItems` function to let the user overrides the behaviour and parse other values.

# JIRA Ticket 

https://smartmobilefactory.atlassian.net/browse/STRATODRVE-2363